### PR TITLE
Answers to your questions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ CPPC = g++ -std=c++11 -Wall -Wextra
 test_inventory: main.o staff.o sword.o
 	${CPPC} main.o staff.o sword.o -o test_inventory
 main.o: sources/main.cpp includes/item.h
-	${CPPC} -c sources/main.cpp includes/item.h
+	${CPPC} -c sources/main.cpp
 staff.o: sources/staff.cpp includes/item.h
-	${CPPC} -c sources/staff.cpp includes/item.h
-sword.o: sources/staff.cpp includes/item.h
-	${CPPC} -c sources/sword.cpp includes/item.h
+	${CPPC} -c sources/staff.cpp
+sword.o: sources/sword.cpp includes/item.h
+	${CPPC} -c sources/sword.cpp
 clean:
 	rm *.o && rm test_inventory

--- a/includes/item.h
+++ b/includes/item.h
@@ -3,23 +3,24 @@
 #include <iostream>
 namespace items{
 	//item interface
+    using stats_t = std::map<std::string, int>;
 	class item{
 	public:
 		std::string name;
-		std::map<std::string, int> stats;
-		virtual int calculate_damage() = 0;
+		stats_t stats;
+		virtual int calculate_damage(stats_t) = 0;
 	};
 
 	class sword : public item{
 	public:
 		sword();
 		//sword(std::string name, std::map<std::string, int> init_stats);
-		virtual int calculate_damage(std::map<std::string, int> character_stats);
+		virtual int calculate_damage(stats_t) override;
 	};
 
 	class staff : public item{
 	public:
 		staff();
-		virtual int calculate_damage(std::map<std::string, int> character_stats);
+		virtual int calculate_damage(stats_t) override;
 	};
 }

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -1,12 +1,12 @@
 #include "../includes/item.h"
 using namespace items;
 int main(){
-	std::map<std::string, int> test_char_stats{
+    stats_t test_char_stats{
 		{"STR" , 2},
 		{"DEX" , 2},
 		{"INT" , 2}
 	};
-	sword test_sword = sword();
+	sword test_sword;
 	std::cout << test_sword.calculate_damage(test_char_stats) << std::endl;
 	return 0;
 }

--- a/sources/staff.cpp
+++ b/sources/staff.cpp
@@ -7,7 +7,7 @@ items::staff::staff(){
 		{"INT" , 3}
 	};
 }
-virtual int items::staff::calculate_damage(std::map<std::string, int> character_stats){
+int items::staff::calculate_damage(stats_t character_stats) {
 	std::cout << "staff damage uses strength";
 	return stats["INT"] + character_stats["INT"];
 }

--- a/sources/sword.cpp
+++ b/sources/sword.cpp
@@ -2,12 +2,12 @@
 items::sword::sword(){
 	name = "Default Sword";
 	stats = {
-		{"STR" : 3},
-		{"DEX" : 1},
-		{"INT" : 1}
-	}
+		{"STR", 3},
+		{"DEX", 1},
+		{"INT", 1}
+	};
 }
-virtual int items::sword::calculate_damage(std::map<std::string, int> character_stats) overide {
+int items::sword::calculate_damage(stats_t character_stats) {
 	std::cout << "Sword damage uses strength";
 	return stats["STR"] + character_stats["STR"];
 }


### PR DESCRIPTION
Fixed a few random compile issues, but the primary issue was:

1. The item base class signature of the calc damage function did not match the signature of the classes attempting to override it.  This isn't overriding, it's shadowing, and is almost always a bug.
2. The virtual keyword can only appear in a class declaration. It doesn't belong in implementation files.

Try this on for size.